### PR TITLE
Update Foundry Documentation resource link

### DIFF
--- a/README.md
+++ b/README.md
@@ -158,7 +158,7 @@ Contributions are always welcome! Open a PR or an issue!
 ## Resources
 
 -   [Chainlink Documentation](https://docs.chain.link/)
--   [Foundry Documentation](https://onbjerg.github.io/foundry-book/)
+-   [Foundry Documentation](https://book.getfoundry.sh/)
 
 ### TODO
 


### PR DESCRIPTION
Foundry book has been moved to: https://book.getfoundry.sh/ from its previous URL: https://onbjerg.github.io/foundry-book/
Ref: https://github.com/foundry-rs/book