### PR TITLE
Fixed all solidity warnings

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,6 @@ broadcast/
 
 node_modules
 package-lock.json
+
+.DS_Store
+src/.DS_Store

--- a/foundry.toml
+++ b/foundry.toml
@@ -1,4 +1,4 @@
-[default]
+[profile.default]
 src = 'src'
 out = 'out'
 libs = ['lib']

--- a/script/APIConsumer.s.sol
+++ b/script/APIConsumer.s.sol
@@ -33,7 +33,7 @@ contract DeployAPIConsumer is Script, HelperConfig {
 
         vm.startBroadcast();
 
-        APIConsumer apiConsumer = new APIConsumer(
+        new APIConsumer(
             oracle,
             jobId,
             chainlinkFee,

--- a/script/HelperConfig.sol
+++ b/script/HelperConfig.sol
@@ -27,6 +27,7 @@ contract HelperConfig {
 
     function getRinkebyEthConfig()
         internal
+        pure
         returns (NetworkConfig memory rinkebyNetworkConfig)
     {
         rinkebyNetworkConfig = NetworkConfig({
@@ -44,6 +45,7 @@ contract HelperConfig {
 
     function getAnvilEthConfig()
         internal
+        pure
         returns (NetworkConfig memory anvilNetworkConfig)
     {
         anvilNetworkConfig = NetworkConfig({

--- a/script/KeepersCounter.s.sol
+++ b/script/KeepersCounter.s.sol
@@ -14,7 +14,7 @@ contract DeployKeepersCounter is Script, HelperConfig {
 
         vm.startBroadcast();
 
-        KeepersCounter keepersCounter = new KeepersCounter(updateInterval);
+        new KeepersCounter(updateInterval);
 
         vm.stopBroadcast();
     }

--- a/script/PriceFeedConsumer.s.sol
+++ b/script/PriceFeedConsumer.s.sol
@@ -22,7 +22,7 @@ contract DeployPriceFeedConsumer is Script, HelperConfig {
 
         vm.startBroadcast();
 
-        PriceFeedConsumer priceFeedConsumer = new PriceFeedConsumer(priceFeed);
+        new PriceFeedConsumer(priceFeed);
 
         vm.stopBroadcast();
     }

--- a/script/VRFConsumerV2.s.sol
+++ b/script/VRFConsumerV2.s.sol
@@ -33,12 +33,13 @@ contract DeployVRFConsumerV2 is Script, HelperConfig {
 
         vm.startBroadcast();
 
-        VRFConsumerV2 vrfConsumerV2 = new VRFConsumerV2(
+        new VRFConsumerV2(
             subscriptionId,
             vrfCoordinator,
             link,
             keyHash
         );
+        
         vm.stopBroadcast();
     }
 }

--- a/src/APIConsumer.sol
+++ b/src/APIConsumer.sol
@@ -35,7 +35,7 @@ contract APIConsumer is ChainlinkClient {
         bytes32 _jobId,
         uint256 _fee,
         address _link
-    ) public {
+    ) {
         if (_link == address(0)) {
             setPublicChainlinkToken();
         } else {

--- a/src/KeepersCounter.sol
+++ b/src/KeepersCounter.sol
@@ -38,13 +38,15 @@ contract KeepersCounter is KeeperCompatibleInterface {
         bytes memory /* checkData */
     )
         public
+        view
         override
         returns (
             bool upkeepNeeded,
-            bytes memory /* performData */
+            bytes memory performData
         )
     {
         upkeepNeeded = (block.timestamp - lastTimeStamp) > interval;
+        performData = bytes(""); 
         // We don't use the checkData in this example. The checkData is defined when the Upkeep was registered.
     }
 

--- a/src/PriceFeedConsumer.sol
+++ b/src/PriceFeedConsumer.sol
@@ -30,11 +30,11 @@ contract PriceFeedConsumer {
      */
     function getLatestPrice() public view returns (int256) {
         (
-            uint80 roundID,
+            /* uint80 roundID */,
             int256 price,
-            uint256 startedAt,
-            uint256 timeStamp,
-            uint80 answeredInRound
+            /* uint256 startedAt */,
+            /* uint256 timeStamp */,
+            /* uint80 answeredInRound */
         ) = priceFeed.latestRoundData();
         return price;
     }

--- a/src/VRFConsumerV2.sol
+++ b/src/VRFConsumerV2.sol
@@ -88,7 +88,6 @@ contract VRFConsumerV2 is VRFConsumerBaseV2 {
         internal
         override
     {
-        require(s_requestId == requestId);
         s_randomWords = randomWords;
         emit ReturnedRandomness(randomWords);
     }

--- a/src/VRFConsumerV2.sol
+++ b/src/VRFConsumerV2.sol
@@ -88,6 +88,7 @@ contract VRFConsumerV2 is VRFConsumerBaseV2 {
         internal
         override
     {
+        require(s_requestId == requestId);
         s_randomWords = randomWords;
         emit ReturnedRandomness(randomWords);
     }

--- a/src/test/mocks/MockOracle.sol
+++ b/src/test/mocks/MockOracle.sol
@@ -118,7 +118,7 @@ contract MockOracle is ChainlinkRequestInterface, LinkTokenReceiver {
      * @dev Sets the LinkToken address for the imported LinkTokenInterface
      * @param _link The address of the LINK token
      */
-    constructor(address _link) public {
+    constructor(address _link) {
         LinkToken = LinkTokenInterface(_link); // external but already deployed and unalterable
     }
 


### PR DESCRIPTION
Foundry warning:
```
warning: Unknown section [default] found in foundry.toml.
```

Solidity warning:
```
Compiler run successful (with warnings)
warning[2462]: Warning: Visibility for constructor is ignored. If you want the contract to be non-deployable, making it "abstract" is sufficient.
  --> src/APIConsumer.sol:33:5:
   |
33 |     constructor(
   |     ^ (Relevant source part starts here and spans across multiple lines).



warning[2462]: Warning: Visibility for constructor is ignored. If you want the contract to be non-deployable, making it "abstract" is sufficient.
   --> src/test/mocks/MockOracle.sol:121:5:
    |
121 |     constructor(address _link) public {
    |     ^ (Relevant source part starts here and spans across multiple lines).



warning[6321]: Warning: Unnamed return variable can remain unassigned. Add an explicit return with value to all non-reverting code paths or name the variable.
  --> src/KeepersCounter.sol:44:13:
   |
44 |             bytes memory /* performData */
   |             ^^^^^^^^^^^^



warning[5667]: Warning: Unused function parameter. Remove or comment out the variable name to silence this warning.
   --> lib/chainlink-brownie-contracts/contracts/src/v0.8/mocks/VRFCoordinatorV2Mock.sol:186:24:
    |
186 |   function addConsumer(uint64 _subId, address _consumer) external pure override {
    |                        ^^^^^^^^^^^^^



warning[5667]: Warning: Unused function parameter. Remove or comment out the variable name to silence this warning.
   --> lib/chainlink-brownie-contracts/contracts/src/v0.8/mocks/VRFCoordinatorV2Mock.sol:186:39:
    |
186 |   function addConsumer(uint64 _subId, address _consumer) external pure override {
    |                                       ^^^^^^^^^^^^^^^^^



warning[5667]: Warning: Unused function parameter. Remove or comment out the variable name to silence this warning.
   --> lib/chainlink-brownie-contracts/contracts/src/v0.8/mocks/VRFCoordinatorV2Mock.sol:190:27:
    |
190 |   function removeConsumer(uint64 _subId, address _consumer) external pure override {
    |                           ^^^^^^^^^^^^^



warning[5667]: Warning: Unused function parameter. Remove or comment out the variable name to silence this warning.
   --> lib/chainlink-brownie-contracts/contracts/src/v0.8/mocks/VRFCoordinatorV2Mock.sol:190:42:
    |
190 |   function removeConsumer(uint64 _subId, address _consumer) external pure override {
    |                                          ^^^^^^^^^^^^^^^^^



warning[5667]: Warning: Unused function parameter. Remove or comment out the variable name to silence this warning.
   --> lib/chainlink-brownie-contracts/contracts/src/v0.8/mocks/VRFCoordinatorV2Mock.sol:194:45:
    |
194 |   function requestSubscriptionOwnerTransfer(uint64 _subId, address _newOwner) external pure override {
    |                                             ^^^^^^^^^^^^^



warning[5667]: Warning: Unused function parameter. Remove or comment out the variable name to silence this warning.
   --> lib/chainlink-brownie-contracts/contracts/src/v0.8/mocks/VRFCoordinatorV2Mock.sol:194:60:
    |
194 |   function requestSubscriptionOwnerTransfer(uint64 _subId, address _newOwner) external pure override {
    |                                                            ^^^^^^^^^^^^^^^^^



warning[5667]: Warning: Unused function parameter. Remove or comment out the variable name to silence this warning.
   --> lib/chainlink-brownie-contracts/contracts/src/v0.8/mocks/VRFCoordinatorV2Mock.sol:198:44:
    |
198 |   function acceptSubscriptionOwnerTransfer(uint64 _subId) external pure override {
    |                                            ^^^^^^^^^^^^^



warning[2072]: Warning: Unused local variable.
  --> script/APIConsumer.s.sol:36:9:
   |
36 |         APIConsumer apiConsumer = new APIConsumer(
   |         ^^^^^^^^^^^^^^^^^^^^^^^



warning[2072]: Warning: Unused local variable.
  --> script/KeepersCounter.s.sol:17:9:
   |
17 |         KeepersCounter keepersCounter = new KeepersCounter(updateInterval);
   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^



warning[2072]: Warning: Unused local variable.
  --> src/PriceFeedConsumer.sol:33:13:
   |
33 |             uint80 roundID,
   |             ^^^^^^^^^^^^^^



warning[2072]: Warning: Unused local variable.
  --> src/PriceFeedConsumer.sol:35:13:
   |
35 |             uint256 startedAt,
   |             ^^^^^^^^^^^^^^^^^



warning[2072]: Warning: Unused local variable.
  --> src/PriceFeedConsumer.sol:36:13:
   |
36 |             uint256 timeStamp,
   |             ^^^^^^^^^^^^^^^^^



warning[2072]: Warning: Unused local variable.
  --> src/PriceFeedConsumer.sol:37:13:
   |
37 |             uint80 answeredInRound
   |             ^^^^^^^^^^^^^^^^^^^^^^



warning[2072]: Warning: Unused local variable.
  --> script/PriceFeedConsumer.s.sol:25:9:
   |
25 |         PriceFeedConsumer priceFeedConsumer = new PriceFeedConsumer(priceFeed);
   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^



warning[5667]: Warning: Unused function parameter. Remove or comment out the variable name to silence this warning.
  --> src/VRFConsumerV2.sol:87:33:
   |
87 |     function fulfillRandomWords(uint256 requestId, uint256[] memory randomWords)
   |                                 ^^^^^^^^^^^^^^^^^



warning[2072]: Warning: Unused local variable.
  --> script/VRFConsumerV2.s.sol:36:9:
   |
36 |         VRFConsumerV2 vrfConsumerV2 = new VRFConsumerV2(
   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^



warning[2018]: Warning: Function state mutability can be restricted to pure
  --> script/HelperConfig.sol:28:5:
   |
28 |     function getRinkebyEthConfig()
   |     ^ (Relevant source part starts here and spans across multiple lines).



warning[2018]: Warning: Function state mutability can be restricted to pure
  --> script/HelperConfig.sol:45:5:
   |
45 |     function getAnvilEthConfig()
   |     ^ (Relevant source part starts here and spans across multiple lines).



warning[2018]: Warning: Function state mutability can be restricted to view
  --> src/KeepersCounter.sol:37:5:
   |
37 |     function checkUpkeep(
   |     ^ (Relevant source part starts here and spans across multiple lines).


```

```
% forge build
[⠔] Compiling...
[⠒] Compiling 4 files with 0.8.15
[⠢] Solc 0.8.15 finished in 1.56s
Compiler run successful

% forge test 
[⠰] Compiling...
No files changed, compilation skipped

Running 1 test for src/test/PriceFeedConsumer.t.sol:PriceFeedConsumerTest
[PASS] testConsumerReturnsStartingValue() (gas: 17429)
Test result: ok. 1 passed; 0 failed; finished in 2.91ms

Running 2 tests for src/test/APIConsumer.t.sol:APIConsumerTest
[PASS] testCanGetResponse() (gas: 103642)
[PASS] testCanMakeRequest() (gas: 106898)
Test result: ok. 2 passed; 0 failed; finished in 3.61ms

Running 3 tests for src/test/VRFConsumerV2.t.sol:VRFConsumerV2Test
[PASS] testCanGetRandomResponse() (gas: 139958)
[PASS] testCanRequestRandomness() (gas: 72738)
[PASS] testEmitsEventOnFulfillment() (gas: 142582)
Test result: ok. 3 passed; 0 failed; finished in 3.76ms

Running 4 tests for src/test/KeepersCounter.t.sol:KeepersCounterTest
[PASS] testCheckupReturnsFalseBeforeTime() (gas: 8757)
[PASS] testCheckupReturnsTrueAfterTime() (gas: 15981)
[PASS] testFuzzingExample(bytes) (runs: 256, μ: 11914, ~: 11873)
[PASS] testPerformUpkeepUpdatesTime() (gas: 42661)
Test result: ok. 4 passed; 0 failed; finished in 42.23ms
```