### PR TITLE
Update makefile deploy-rinkeby

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -31,7 +31,7 @@ lint :; solhint src/**/*.sol && solhint src/*.sol
 anvil :; anvil -m 'test test test test test test test test test test test junk'
 
 # use the "@" to hide the command from your shell 
-deploy-rinkeby :; @forge script script/${contract}.s.sol:Deploy${contract} --rpc-url ${RINKEBY_RPC_URL}  --private-key ${PRIVATE_KEY} --broadcast --verify --etherscan-api-key ${ETHERSCAN_API_KEY}  -vvvv
+deploy-rinkeby :; @forge script script/${contract}.s.sol:Deploy${contract} --rpc-url ${RINKEBY_RPC_URL}  --private-key ${PRIVATE_KEY} --broadcast --verify --etherscan-api-key ${ETHERSCAN_KEY}  -vvvv
 
 # This is the private key of account from the mnemonic from the "make anvil" command
 deploy-anvil :; @forge script script/${contract}.s.sol:Deploy${contract} --rpc-url http://localhost:8545  --private-key 0xac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f2ff80 --broadcast 

--- a/Makefile
+++ b/Makefile
@@ -31,7 +31,7 @@ lint :; solhint src/**/*.sol && solhint src/*.sol
 anvil :; anvil -m 'test test test test test test test test test test test junk'
 
 # use the "@" to hide the command from your shell 
-deploy-rinkeby :; @forge script script/${contract}.s.sol:Deploy${contract} --rpc-url ${RINKEBY_RPC_URL}  --private-key ${PRIVATE_KEY} --broadcast --verify --etherscan-api-key ${ETHERSCAN_KEY}  -vvvv
+deploy-rinkeby :; @forge script script/${contract}.s.sol:Deploy${contract} --rpc-url ${RINKEBY_RPC_URL}  --private-key ${PRIVATE_KEY} --verify --etherscan-api-key ${ETHERSCAN_KEY}  -vvvv
 
 # This is the private key of account from the mnemonic from the "make anvil" command
 deploy-anvil :; @forge script script/${contract}.s.sol:Deploy${contract} --rpc-url http://localhost:8545  --private-key 0xac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f2ff80 --broadcast 


### PR DESCRIPTION
In .env.example, variable for etherscan api key is ETHERSCAN_KEY, while in the makefile it is ETHERSCAN_API_KEY.
Adjust makefile to use ETHERSCAN_KEY so script can run using the key specified in the .env file