### PR TITLE
Fix `InvalidConsumer()` error in VRF test cases

### DIFF
--- a/src/test/VRFConsumerV2.t.sol
+++ b/src/test/VRFConsumerV2.t.sol
@@ -32,6 +32,7 @@ contract VRFConsumerV2Test is Test {
             address(linkToken),
             keyHash
         );
+        vrfCoordinator.addConsumer(subId, address(vrfConsumer));
     }
 
     function testCanRequestRandomness() public {


### PR DESCRIPTION
```
Running 3 tests for src/test/VRFConsumerV2.t.sol:VRFConsumerV2Test
[FAIL. Reason: InvalidConsumer()] testCanGetRandomResponse() (gas: 13281)
Traces:
  [13281] VRFConsumerV2Test::testCanGetRandomResponse()
    ├─ [8116] VRFConsumerV2::requestRandomWords()
    │   ├─ [3024] VRFCoordinatorV2Mock::requestRandomWords(0x0000000000000000000000000000000000000000000000000000000000000000, 1, 3, 100000, 2)
    │   │   └─ ← "InvalidConsumer()"
    │   └─ ← "InvalidConsumer()"
    └─ ← "InvalidConsumer()"

[FAIL. Reason: InvalidConsumer()] testCanRequestRandomness() (gas: 16039)
Traces:
  [16039] VRFConsumerV2Test::testCanRequestRandomness()
    ├─ [2317] VRFConsumerV2::s_requestId() [staticcall]
    │   └─ ← 0
    ├─ [8116] VRFConsumerV2::requestRandomWords()
    │   ├─ [3024] VRFCoordinatorV2Mock::requestRandomWords(0x0000000000000000000000000000000000000000000000000000000000000000, 1, 3, 100000, 2)
    │   │   └─ ← "InvalidConsumer()"
    │   └─ ← "InvalidConsumer()"
    └─ ← "InvalidConsumer()"

[FAIL. Reason: InvalidConsumer()] testEmitsEventOnFulfillment() (gas: 13259)
Traces:
  [13259] VRFConsumerV2Test::testEmitsEventOnFulfillment()
    ├─ [8116] VRFConsumerV2::requestRandomWords()
    │   ├─ [3024] VRFCoordinatorV2Mock::requestRandomWords(0x0000000000000000000000000000000000000000000000000000000000000000, 1, 3, 100000, 2)
    │   │   └─ ← "InvalidConsumer()"
    │   └─ ← "InvalidConsumer()"
    └─ ← "InvalidConsumer()"

Test result: FAILED. 0 passed; 3 failed; finished in 2.48ms



```