### PR TITLE
Use Local Memory Type Variable Instead of Global Storage Type Variable in Event to Save Gasmain

### DIFF
--- a/src/APIConsumer.sol
+++ b/src/APIConsumer.sol
@@ -98,7 +98,7 @@ contract APIConsumer is ChainlinkClient {
         recordChainlinkFulfillment(_requestId)
     {
         volume = _volume;
-        emit DataFullfilled(volume);
+        emit DataFullfilled(_volume);
     }
 
     /**


### PR DESCRIPTION
Hi, we recently have conducted a systematic study about Solidity event usage, evolution, and impact, and we are attempting to build a tool to improve the practice of Solidity event use based on our findings. We have tried our prototype tool on some of the most popular GitHub Solidity repositories, and for your repository, we find a potential optimization of gas consumption arisen from event use.

The point is that when we use emit operation to store the value of a certain variable, local memory type variable would be preferable to global storage type (state) variable if they hold the same value. The reason is that an extra SLOAD operation would be needed to access the variable if it is storage type, and the SLOAD operation costs 800 gas.