### PR TITLE
Update .env.example

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,3 +1,3 @@
 RINKEBY_RPC_URL=asdfasdf 
 PRIVATE_KEY=asdfasdf 
-ETHERSCAN_KEY=asdfasfs
+ETHERSCAN_API_KEY=asdfasfs


### PR DESCRIPTION
https://github.com/afrideva/foundry-starter-kit/blob/f741f4844e1ae8d79909f3ad8f3f3a8245674728/Makefile#L34 and setup instructions refer to a different env key than currently defined