### PR TITLE
Sepolia migration

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,3 +1,3 @@
-GOERLI_RPC_URL=asdfasdf 
+SEPOLIA_RPC_URL=asdfasdf 
 PRIVATE_KEY=asdfasdf 
 ETHERSCAN_API_KEY=asdfasfs

--- a/Makefile
+++ b/Makefile
@@ -31,7 +31,7 @@ lint :; solhint src/**/*.sol && solhint src/*.sol
 anvil :; anvil -m 'test test test test test test test test test test test junk'
 
 # use the "@" to hide the command from your shell 
-deploy-goerli :; @forge script script/${contract}.s.sol:Deploy${contract} --rpc-url ${GOERLI_RPC_URL}  --private-key ${PRIVATE_KEY} --broadcast --verify --etherscan-api-key ${ETHERSCAN_API_KEY}  -vvvv
+deploy-sepolia :; @forge script script/${contract}.s.sol:Deploy${contract} --rpc-url ${SEPOLIA_RPC_URL}  --private-key ${PRIVATE_KEY} --broadcast --verify --etherscan-api-key ${ETHERSCAN_API_KEY}  -vvvv
 
 # This is the private key of account from the mnemonic from the "make anvil" command
 deploy-anvil :; @forge script script/${contract}.s.sol:Deploy${contract} --rpc-url http://localhost:8545  --private-key 0xac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f2ff80 --broadcast 

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-*Note: This repo has been recently updated for Goerli*
+*Note: This repo has been recently updated for Sepolia*
 
 # Foundry Starter Kit
 
@@ -73,37 +73,36 @@ Deploying to a network uses the [foundry scripting system](https://book.getfound
 
 ## Setup
 
-We'll demo using the Goerli testnet. (Go here for [testnet goerli ETH](https://faucets.chain.link/).)
+We'll demo using the Sepolia testnet. (Go here for [testnet sepolia ETH](https://faucets.chain.link/).)
 
 You'll need to add the following variables to a `.env` file:
 
--   `GOERLI_RPC_URL`: A URL to connect to the blockchain. You can get one for free from [Alchemy](https://www.alchemy.com/). 
--   `PRIVATE_KEY`: A private key from your wallet. You can get a private key from a new [Metamask](https://metamask.io/) account
+-   `SEPOLIA_RPC_URL`: A URL to connect to the blockchain. You can get one for free from [Infura](https://www.infura.io/) account
     -   Additionally, if you want to deploy to a testnet, you'll need test ETH and/or LINK. You can get them from [faucets.chain.link](https://faucets.chain.link/).
 -   Optional `ETHERSCAN_API_KEY`: If you want to verify on etherscan
 
 ## Deploying
 
 ```
-make deploy-goerli contract=<CONTRACT_NAME>
+make deploy-sepolia contract=<CONTRACT_NAME>
 ```
 
 For example:
 
 ```
-make deploy-goerli contract=PriceFeedConsumer
+make deploy-sepolia contract=PriceFeedConsumer
 ```
 
 This will run the forge script, the script it's running is:
 
 ```
-@forge script script/${contract}.s.sol:Deploy${contract} --rpc-url ${GOERLI_RPC_URL}  --private-key ${PRIVATE_KEY} --broadcast --verify --etherscan-api-key ${ETHERSCAN_API_KEY}  -vvvv
+@forge script script/${contract}.s.sol:Deploy${contract} --rpc-url ${SEPOLIA_RPC_URL}  --private-key ${PRIVATE_KEY} --broadcast --verify --etherscan-api-key ${ETHERSCAN_API_KEY}  -vvvv
 ```
 
 If you don't have an `ETHERSCAN_API_KEY`, you can also just run:
 
 ```
-@forge script script/${contract}.s.sol:Deploy${contract} --rpc-url ${GOERLI_RPC_URL}  --private-key ${PRIVATE_KEY} --broadcast 
+@forge script script/${contract}.s.sol:Deploy${contract} --rpc-url ${SEPOLIA_RPC_URL}  --private-key ${PRIVATE_KEY} --broadcast 
 ```
 
 These pull from the files in the `script` folder. 
@@ -126,7 +125,7 @@ Then, you can deploy to it with:
 make deploy-anvil contract=<CONTRACT_NAME>
 ```
 
-Similar to `deploy-goerli`
+Similar to `deploy-sepolia`
 
 ### Working with other chains
 

--- a/README.md
+++ b/README.md
@@ -78,6 +78,7 @@ We'll demo using the Sepolia testnet. (Go here for [testnet sepolia ETH](https:/
 You'll need to add the following variables to a `.env` file:
 
 -   `SEPOLIA_RPC_URL`: A URL to connect to the blockchain. You can get one for free from [Infura](https://www.infura.io/) account
+-   `PRIVATE_KEY`: A private key from your wallet. You can get a private key from a new [Metamask](https://metamask.io/) account
     -   Additionally, if you want to deploy to a testnet, you'll need test ETH and/or LINK. You can get them from [faucets.chain.link](https://faucets.chain.link/).
 -   Optional `ETHERSCAN_API_KEY`: If you want to verify on etherscan
 

--- a/script/HelperConfig.sol
+++ b/script/HelperConfig.sol
@@ -19,27 +19,27 @@ contract HelperConfig {
     mapping(uint256 => NetworkConfig) public chainIdToNetworkConfig;
 
     constructor() {
-        chainIdToNetworkConfig[5] = getGoerliEthConfig();
+        chainIdToNetworkConfig[11155111] = getSepoliaEthConfig();
         chainIdToNetworkConfig[31337] = getAnvilEthConfig();
 
         activeNetworkConfig = chainIdToNetworkConfig[block.chainid];
     }
 
-    function getGoerliEthConfig()
+    function getSepoliaEthConfig()
         internal
         pure
-        returns (NetworkConfig memory goerliNetworkConfig)
+        returns (NetworkConfig memory sepoliaNetworkConfig)
     {
-        goerliNetworkConfig = NetworkConfig({
-            oracle: 0xCC79157eb46F5624204f47AB42b3906cAA40eaB7,
+        sepoliaNetworkConfig = NetworkConfig({
+            oracle: 0x6090149792dAAeE9D1D568c9f9a6F6B46AA29eFD,
             jobId: "ca98366cc7314957b8c012c72f05aeeb",
             chainlinkFee: 1e17,
-            link: 0x326C977E6efc84E512bB9C30f76E30c160eD06FB,
+            link: 0x779877A7B0D9E8603169DdbD7836e478b4624789,
             updateInterval: 60, // every minute
-            priceFeed: 0xD4a33860578De61DBAbDc8BFdb98FD742fA7028e, // ETH / USD
+            priceFeed: 0x694AA1769357215DE4FAC081bf1f309aDC325306, // ETH / USD
             subscriptionId: 0, // UPDATE ME!
-            vrfCoordinator: 0x2Ca8E0C643bDe4C2E08ab1fA0da3401AdAD7734D,
-            keyHash: 0x79d3d8832d904592c0bf9818b621522c988bb8b0c05cdc3b15aea1b6e8db0c15
+            vrfCoordinator: 0x8103B0A8A00be2DDC778e6e7eaa21791Cd364625,
+            keyHash: 0x474e34a077df58807dbe9c96d3c009b23b3c6d0cce433e59bbf5b34f823bc56c
         });
     }
 


### PR DESCRIPTION
### Describe

-  Introduced Sepolia as the default testnet for Ethereum instead of Goerli

### Related issues and/or PRs

- None