### PR TITLE
Fix README Dependencies #23, #15

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,7 +51,6 @@ And you probably already have `make` installed... but if not [try looking here.]
 ```sh
 git clone https://github.com/smartcontractkit/foundry-starter-kit
 cd foundry-starter-kit
-make # This installs the project's dependencies.
 make test
 ```
 


### PR DESCRIPTION
Removed the `make` command from the Quickstart section of the README to eliminate errors related to dependency conflicts. This change directly addresses issues #23 and #15.

- Ensures compatibility with project dependencies by avoiding the `make` command which previously led to submodule path conflicts and identifier declaration errors.

- Prevents issues for new users.